### PR TITLE
fix(docker-image): update ghcr.io/esphome/esphome docker tag to v2024…

### DIFF
--- a/apps/default/esphome/release.yaml
+++ b/apps/default/esphome/release.yaml
@@ -17,7 +17,7 @@ spec:
   values:
     image:
       repository: ghcr.io/esphome/esphome
-      tag: 2024.2.1@sha256:a3c97473f2c303c29c8bd96dc9d4803de14edff5c89b6069814656c2beebe5ce
+      tag: 2024.2.2@sha256:96e4ea5664de466af3549f28862290bbbc2bd1cadf444393c91a97256ed51ae8
     
     persistence:
       config:


### PR DESCRIPTION
….2.2

| datasource | package                 | from     | to       |
| ---------- | ----------------------- | -------- | -------- |
| docker     | ghcr.io/esphome/esphome | 2024.2.1 | 2024.2.2 |